### PR TITLE
feat: use Uint8Array instead of Buffer

### DIFF
--- a/test/object-mode.js
+++ b/test/object-mode.js
@@ -64,15 +64,15 @@ test('data send/receive Buffer {objectMode: true}', function (t) {
   function tryTest () {
     if (!peer1.connected || !peer2.connected) return
 
-    peer1.send(Buffer.from('this is a Buffer'))
+    peer1.send(Uint8Array.from('this is a Buffer'))
     peer2.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-      t.deepEqual(data, Buffer.from('this is a Buffer'), 'got correct message')
+      t.ok(data instanceof Uint8Array, 'data is a Buffer')
+      t.deepEqual(data, Uint8Array.from('this is a Buffer'), 'got correct message')
 
-      peer2.send(Buffer.from('this is another Buffer'))
+      peer2.send(Uint8Array.from('this is another Uint8Array'))
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-        t.deepEqual(data, Buffer.from('this is another Buffer'), 'got correct message')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
+        t.deepEqual(data, Uint8Array.from('this is another Uint8Array'), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })
         peer1.destroy()
@@ -104,13 +104,13 @@ test('data send/receive Uint8Array {objectMode: true}', function (t) {
     peer2.on('data', function (data) {
       // binary types always get converted to Buffer
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-      t.deepEqual(data, Buffer.from([0, 1, 2]), 'got correct message')
+      t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
+      t.deepEqual(data, Uint8Array.from([0, 1, 2]), 'got correct message')
 
       peer2.send(new Uint8Array([1, 2, 3]))
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-        t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct message')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
+        t.deepEqual(data, Uint8Array.from([1, 2, 3]), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })
         peer1.destroy()
@@ -140,13 +140,13 @@ test('data send/receive ArrayBuffer {objectMode: true}', function (t) {
 
     peer1.send(new Uint8Array([0, 1, 2]).buffer)
     peer2.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-      t.deepEqual(data, Buffer.from([0, 1, 2]), 'got correct message')
+      t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
+      t.deepEqual(data, Uint8Array.from([0, 1, 2]), 'got correct message')
 
       peer2.send(new Uint8Array([1, 2, 3]).buffer)
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
-        t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct message')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
+        t.deepEqual(data, Uint8Array.from([1, 2, 3]), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })
         peer1.destroy()


### PR DESCRIPTION
fix: use build in readable-stream.destroy()

readable-stream 3 added support for .destroy, this will now just use
the built in destroy and avoid overrind .destroyed, as that is handled
automatically

BREAKING CHANGES: uses Uint8Array instead of Buffer